### PR TITLE
ci: make release workflow manual-only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,6 @@
 name: Release
 
 on:
-  push:
-    branches:
-      - main
   workflow_dispatch:
     inputs:
       dry_run:
@@ -39,7 +36,7 @@ jobs:
         id: semantic
         uses: cycjimmy/semantic-release-action@v4
         with:
-          dry_run: ${{ inputs.dry_run || false }}
+          dry_run: ${{ inputs.dry_run }}
           extra_plugins: |
             conventional-changelog-conventionalcommits
         env:
@@ -48,7 +45,7 @@ jobs:
   build:
     name: Build Package
     needs: release
-    if: needs.release.outputs.new_release_published == 'true' && (inputs.dry_run == false || inputs.dry_run == null)
+    if: needs.release.outputs.new_release_published == 'true' && inputs.dry_run == false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -72,7 +69,7 @@ jobs:
   publish:
     name: Publish to PyPI
     needs: [release, build]
-    if: needs.release.outputs.new_release_published == 'true' && (inputs.dry_run == false || inputs.dry_run == null)
+    if: needs.release.outputs.new_release_published == 'true' && inputs.dry_run == false
     runs-on: ubuntu-latest
     environment: pypi  # Requires approval if configured in GitHub Settings
     permissions:


### PR DESCRIPTION
Remove auto-trigger on push to main - releases now require manual dispatch