### PR TITLE
fix: remove @semantic-release/git to work with branch protection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,8 +39,6 @@ jobs:
           dry_run: ${{ inputs.dry_run }}
           extra_plugins: |
             conventional-changelog-conventionalcommits
-            @semantic-release/changelog
-            @semantic-release/git
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -32,14 +32,6 @@
         ]
       }
     }],
-    ["@semantic-release/changelog", {
-      "changelogFile": "docs/changelog.md",
-      "changelogTitle": "# Changelog\n\nAll notable changes to pydantic-marshmallow will be documented here."
-    }],
-    ["@semantic-release/git", {
-      "assets": ["docs/changelog.md"],
-      "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
-    }],
     "@semantic-release/github"
   ]
 }


### PR DESCRIPTION
Branch protection prevents pushing commits to main. Remove changelog commit and git plugins since setuptools-scm versions from tags anyway. Release notes are still created in GitHub Releases.

**Changes:**
- Remove \@semantic-release/changelog\ plugin
- Remove \@semantic-release/git\ plugin  
- Keep \@semantic-release/github\ for GitHub Release creation

After merging, re-run the Release workflow to publish to PyPI.