### PR TITLE
docs: document metadata forwarding, constraint mapping, and instance caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ The bridge delegates validation to Pydantic's Rust-powered core, bypassing Marsh
 - **Partial Loading**: `partial=True` or `partial=('field1', 'field2')`
 - **Unknown Fields**: `unknown=RAISE/EXCLUDE/INCLUDE`
 - **Computed Fields**: Pydantic `@computed_field` support in serialization
-- **Metadata Forwarding**: Pydantic `Field()` metadata (description, title, examples) auto-forwarded to Marshmallow for OpenAPI generation
-- **Constraint Mapping**: Pydantic constraints (min_length, max_length, ge/le, pattern) mapped to Marshmallow validators for OpenAPI
+- **Metadata Forwarding**: Pydantic `Field()` metadata (description, title, examples, `json_schema_extra`, etc.) auto-forwarded to Marshmallow for OpenAPI generation
+- **Constraint Mapping**: Pydantic constraints (min_length, max_length, ge/le, gt/lt, pattern, etc.) mapped to Marshmallow validators for OpenAPI
 - **HybridModel Caching**: Thread-safe instance caching for hookless schemas
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ The bridge delegates validation to Pydantic's Rust-powered core, bypassing Marsh
 - **Partial Loading**: `partial=True` or `partial=('field1', 'field2')`
 - **Unknown Fields**: `unknown=RAISE/EXCLUDE/INCLUDE`
 - **Computed Fields**: Pydantic `@computed_field` support in serialization
+- **Metadata Forwarding**: Pydantic `Field()` metadata (description, title, examples) auto-forwarded to Marshmallow for OpenAPI generation
+- **Constraint Mapping**: Pydantic constraints (min_length, max_length, ge/le, pattern) mapped to Marshmallow validators for OpenAPI
+- **HybridModel Caching**: Thread-safe instance caching for hookless schemas
 
 ## Installation
 

--- a/docs/api/hybrid.md
+++ b/docs/api/hybrid.md
@@ -88,3 +88,19 @@ Use `PydanticSchema` when you need:
 - Custom validators on the schema
 - Field filtering (`only`, `exclude`, `load_only`, `dump_only`)
 - Full control over schema behavior
+
+## Performance
+
+### Instance Caching
+
+`HybridModel` caches default schema instances for hookless schemas, avoiding
+the overhead of creating a new schema object on every `ma_load()` / `ma_dump()` call.
+
+- **Hookless schemas**: Cached and reused (thread-safe via `RLock`)
+- **Schemas with hooks**: Fresh instance every call to prevent mutable state leaks
+- Passing `**kwargs` to `ma_load()` always creates a fresh instance
+
+### Thread Safety
+
+All `ma_load()`, `ma_loads()`, `ma_dump()`, and `ma_dumps()` methods are safe
+to call from multiple threads concurrently.

--- a/docs/api/hybrid.md
+++ b/docs/api/hybrid.md
@@ -98,7 +98,7 @@ the overhead of creating a new schema object on every `ma_load()` / `ma_dump()` 
 
 - **Hookless schemas**: Cached and reused (thread-safe via `RLock`)
 - **Schemas with hooks**: Fresh instance every call to prevent mutable state leaks
-- Passing `**kwargs` to `ma_load()` always creates a fresh instance
+- Passing `**kwargs` to any `ma_load*` / `ma_dump*` method always creates a fresh instance
 
 ### Thread Safety
 

--- a/docs/guide/field-options.md
+++ b/docs/guide/field-options.md
@@ -187,7 +187,7 @@ Pydantic field constraints are mapped to Marshmallow validators so that ecosyste
 | Pydantic Constraint | Marshmallow Validator | OpenAPI Output |
 |--------------------|-----------------------|----------------|
 | `min_length` / `max_length` | `Length(min=, max=)` | `minLength` / `maxLength` |
-| `ge` / `le` / `gt` / `lt` | `Range(min=, max=)` | `minimum` / `maximum` |
+| `ge` / `le` / `gt` / `lt` | `Range(min=, max=)` | `minimum` / `maximum` / `exclusiveMinimum` / `exclusiveMaximum` |
 | `pattern` | `Regexp(regex)` | `pattern` |
 
 ```python

--- a/docs/guide/field-options.md
+++ b/docs/guide/field-options.md
@@ -136,3 +136,76 @@ schema.dump(user, exclude_defaults=True)
 schema.dump(user, exclude_unset=True)
 # {"name": "Alice"}
 ```
+
+## Metadata Forwarding
+
+Pydantic `Field()` metadata is automatically forwarded to Marshmallow fields, enabling ecosystem tools like **apispec** and **flask-smorest** to generate accurate OpenAPI schemas.
+
+!!! info "Metadata is merged"
+    Forwarded metadata is **merged** into any existing Marshmallow field metadata
+    (e.g., metadata set by the type mapping), not replaced.
+
+Supported metadata:
+
+| Pydantic `Field()` | Marshmallow `field.metadata` key |
+|---------------------|----------------------------------|
+| `description="..."` | `"description"` |
+| `title="..."` | `"title"` |
+| `examples=[...]` | `"examples"` |
+| `json_schema_extra={...}` | `"json_schema_extra"` |
+
+```python
+from pydantic import BaseModel, Field
+from pydantic_marshmallow import PydanticSchema
+
+class Product(BaseModel):
+    name: str = Field(description="Product display name", title="Name")
+    price: float = Field(description="Price in USD", examples=[9.99, 19.99])
+
+ProductSchema = PydanticSchema.from_model(Product)
+schema = ProductSchema()
+
+# Metadata is available on the Marshmallow field
+print(schema.fields["name"].metadata)
+# {"description": "Product display name", "title": "Name"}
+
+# apispec reads this automatically for OpenAPI generation
+```
+
+## Constraint-to-Validator Mapping
+
+Pydantic field constraints are mapped to Marshmallow validators so that ecosystem tools can generate accurate OpenAPI schemas with `minLength`, `maxLength`, `minimum`, `maximum`, and `pattern`.
+
+!!! note "Validation is still Pydantic's job"
+    These validators are **never invoked during `load()`** — Pydantic owns all validation.
+    They exist solely for schema introspection by tools like apispec.
+
+!!! info "Validators are appended"
+    Constraint validators are **appended** to any existing field validators
+    (e.g., `OneOf` for `Literal` types), not replaced.
+
+| Pydantic Constraint | Marshmallow Validator | OpenAPI Output |
+|--------------------|-----------------------|----------------|
+| `min_length` / `max_length` | `Length(min=, max=)` | `minLength` / `maxLength` |
+| `ge` / `le` / `gt` / `lt` | `Range(min=, max=)` | `minimum` / `maximum` |
+| `pattern` | `Regexp(regex)` | `pattern` |
+
+```python
+from pydantic import BaseModel, Field
+from pydantic_marshmallow import PydanticSchema
+
+class User(BaseModel):
+    name: str = Field(min_length=1, max_length=100)
+    age: int = Field(ge=0, le=150)
+    email: str = Field(pattern=r"^[\w.-]+@[\w.-]+\.\w+$")
+
+UserSchema = PydanticSchema.from_model(User)
+schema = UserSchema()
+
+# Validators are set on the Marshmallow fields
+print(schema.fields["name"].validators)
+# [Length(min=1, max=100)]
+
+print(schema.fields["age"].validators)
+# [Range(min=0, max=150)]
+```

--- a/src/pydantic_marshmallow/bridge.py
+++ b/src/pydantic_marshmallow/bridge.py
@@ -2,7 +2,7 @@
 Bridge between Pydantic models and Marshmallow schemas.
 
 Pydantic's Rust-based validation with full Marshmallow compatibility.
-Flow: Input → Marshmallow pre_load → PYDANTIC VALIDATES → Marshmallow post_load → Output
+Flow: Input → pre_load → PYDANTIC VALIDATES → @validates → @validates_schema → post_load → Output
 """
 
 from __future__ import annotations
@@ -1492,6 +1492,12 @@ class HybridModel(BaseModel):
 
     This provides a single class that gives you both Pydantic model
     capabilities AND Marshmallow schema functionality.
+
+    Instance Caching:
+        ``ma_load()`` / ``ma_dump()`` cache a default schema instance for
+        performance.  Schemas with hooks (pre_load, post_load, @validates,
+        pre_dump, post_dump) always get a fresh instance to prevent leaked
+        mutable state.  The cache is protected by an ``RLock``.
 
     Example:
         class User(HybridModel):

--- a/src/pydantic_marshmallow/bridge.py
+++ b/src/pydantic_marshmallow/bridge.py
@@ -1501,7 +1501,7 @@ class HybridModel(BaseModel):
     Instance Caching:
         ``ma_load()`` / ``ma_dump()`` cache a default schema instance for
         performance.  Schemas with hooks (pre_load, post_load, @validates,
-        pre_dump, post_dump) always get a fresh instance to prevent leaked
+        @validates_schema, pre_dump, post_dump) always get a fresh instance to prevent leaked
         mutable state.  The cache is protected by an ``RLock``.
 
     Example:

--- a/src/pydantic_marshmallow/field_conversion.py
+++ b/src/pydantic_marshmallow/field_conversion.py
@@ -57,8 +57,6 @@ def convert_pydantic_field(
       Validators are **appended** to any existing ``ma_field.validators`` (e.g., ``OneOf``
       for ``Literal`` types), not replaced.  These validators exist solely for OpenAPI
       schema introspection (apispec/flask-smorest); Pydantic owns actual validation.
-    - Metadata forwarding (description, title, examples, json_schema_extra → MA metadata)
-    - Constraint-to-validator mapping (min_length, max_length, ge/le/gt/lt, pattern → MA validators)
 
     Args:
         field_name: Name of the field

--- a/src/pydantic_marshmallow/field_conversion.py
+++ b/src/pydantic_marshmallow/field_conversion.py
@@ -50,6 +50,12 @@ def convert_pydantic_field(
     - Default values (static and factory)
     - Field aliases (data_key)
     - Optional/None handling (allow_none)
+    - Metadata forwarding (description, title, examples, json_schema_extra)
+      Metadata is **merged** into any existing ``ma_field.metadata``, not replaced.
+    - Constraint-to-validator mapping (min_length, max_length, ge/le/gt/lt, pattern)
+      Validators are **appended** to any existing ``ma_field.validators`` (e.g., ``OneOf``
+      for ``Literal`` types), not replaced.  These validators exist solely for OpenAPI
+      schema introspection (apispec/flask-smorest); Pydantic owns actual validation.
 
     Args:
         field_name: Name of the field


### PR DESCRIPTION
## Summary

Documentation-only PR covering the three features added in PR #23 (metadata forwarding, constraint-to-validator mapping, HybridModel instance caching).

**105 lines changed** across 5 files — no logic changes.

## Changes

### Published docs (mkdocs)
- **`docs/guide/field-options.md`** — New sections: Metadata Forwarding (with merge note) and Constraint-to-Validator Mapping (with extend note + OpenAPI table)
- **`docs/api/hybrid.md`** — New Performance section: Instance Caching behavior + Thread Safety

### Source docstrings
- **`bridge.py`** — Module docstring flow updated to include `@validates` / `@validates_schema`; HybridModel class docstring adds instance caching note
- **`field_conversion.py`** — `convert_pydantic_field()` docstring clarifies merge/extend/OpenAPI-only behavior

### README
- **`README.md`** — Three new feature bullets (Metadata Forwarding, Constraint Mapping, HybridModel Caching)

## Verification
- 648/648 tests passing
- Docker quick tests pass (MA3 + MA4)
- No artifacts included (clean-artifacts check passed)